### PR TITLE
Add footer author email link

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -141,7 +141,7 @@ Open http://localhost:18001/admin</code></pre>
 
     <footer class="footer">
       <p>CGA / ContextGraphAgent</p>
-      <p class="footer-credit">Created and authored by <strong>Nate Scott</strong>.</p>
+      <p class="footer-credit">Created and authored by <a href="mailto:nate@ucia.us" aria-label="Email project author"><strong>Nate Scott</strong></a>.</p>
     </footer>
   </div>
 

--- a/src/tests/test_pages_site.py
+++ b/src/tests/test_pages_site.py
@@ -24,7 +24,8 @@ def test_promotional_site_keeps_author_credit_to_footer() -> None:
 
     assert index.count("Nate Scott") == 1
     assert 'class="footer-credit"' in index
-    assert "Created and authored by <strong>Nate Scott</strong>" in index
+    assert 'href="mailto:nate@ucia.us"' in index
+    assert "Created and authored by <a href=\"mailto:nate@ucia.us\" aria-label=\"Email project author\"><strong>Nate Scott</strong></a>" in index
     assert "by Nate Scott" not in index
     assert "Author spotlight" not in index
     assert "#author" not in index


### PR DESCRIPTION
## Summary
- Add a mailto:nate@ucia.us link to the footer author credit on the public CGA site
- Update the Pages site test to assert the mailto link while keeping the visible author credit footer-only

## Policy Checklist
- JWT/token entropy policy applied
- Data policy applied for pgvector/sqlite-vec/graph

## Tests
- .\\.venv\\Scripts\\python -m pytest src/tests/test_pages_site.py