### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: Bug report
+description: Report a reproducible problem in CGA.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve CGA. Please include enough detail for maintainers to reproduce the problem.
+
+  - type: input
+    id: version
+    attributes:
+      label: CGA version
+      description: Use the version from the README, release artifact, or Admin UI when available.
+      placeholder: "1.30.44"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Admin UI
+        - MCP server
+        - Graph indexing
+        - Work briefing
+        - Docker/Desktop packaging
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened, and what did you expect to happen?
+      placeholder: Describe the issue clearly and concisely.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: List the smallest set of steps that reproduces the problem.
+      placeholder: |
+        1. Start CGA with ...
+        2. Open ...
+        3. Click ...
+        4. See ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, Docker/Desktop version, browser, Python version, and any relevant deployment details.
+      placeholder: "Windows 11, Docker Desktop 4.x, Chrome, Python 3.11"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant logs or attach screenshots. Remove secrets, tokens, and private data first.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: CGA documentation
+    url: https://github.com/nascousa/cga#readme
+    about: Check the README and project documentation before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Suggest an improvement or new capability for CGA.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please describe the workflow or outcome you want CGA to support.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Admin UI
+        - MCP server
+        - Graph indexing
+        - Work briefing
+        - Docker/Desktop packaging
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do, and what currently gets in the way?
+      placeholder: Describe the user workflow, limitation, or desired outcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should CGA do differently?
+      placeholder: Describe the change you would like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Share any workaround, alternate design, or related tool you considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add links, screenshots, examples, or constraints that would help evaluate the request.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds GitHub issue forms for bug reports and feature requests, plus issue template configuration. This is a repository metadata/template-only change.

## Validation

- [x] Unit/E2E tests pass locally (N/A: GitHub issue template-only change)
- [x] New dependencies were checked for CVEs/CVSS threshold policy (N/A: no dependency changes)
- [x] License, NOTICE, and third-party notices were updated if dependencies, fonts/icons/images, browser assets, container images, distribution terms, or acknowledgements changed (N/A)
- [x] DISCLAIMER.md was updated if usage risks, sensitive-data handling, AI/automation behavior, or third-party service boundaries changed (N/A)
- [x] This change was developed on `dev/*` (or `hotfix/*`) branch and not committed directly to `main`
- [x] `docs/deploy_key.md` is updated with the current public deploy key when deploy credentials changed (N/A)
- [x] Mermaid diagrams were updated if architecture/data-flow/schema changed (N/A)
- [x] Docker CPU/Memory limits are configured via env variables when applicable (N/A)

Local validation:

- Parsed all new issue template YAML files successfully
- Ran `git diff --check -- .github/ISSUE_TEMPLATE`

## Policy Checklist

- [x] JWT/token entropy policy applied (algorithm, key strength, claims, TTL, rotation) (N/A: no authentication or token changes)
- [x] Data policy applied for pgvector/sqlite-vec/graph usage and index/query constraints (N/A: no data/index/query changes)